### PR TITLE
Fix failed job by removing invalid .venv cache

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -39,8 +39,7 @@ jobs:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-archive-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            ${{ env.PYTHON_VERSION }}-
-            pip-
+            ${{ env.PYTHON_VERSION }}-archive-
 
       - name: Install dependencies
         run: pipenv sync

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "7 11 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - fix-separate-cache-key
 
 env:
   CI: true
@@ -34,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ env.PYTHON_VERSION }}-archive-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
             ${{ env.PYTHON_VERSION }}-
             pip-

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: "7 11 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - fix-separate-cache-key
 
 env:
   CI: true
@@ -37,9 +34,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ env.PYTHON_VERSION }}-archive-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            ${{ env.PYTHON_VERSION }}-archive-
+            ${{ env.PYTHON_VERSION }}-
+            pip-
 
       - name: Check and conditionally remove invalid virtual environment
         run: |

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -41,6 +41,17 @@ jobs:
           restore-keys: |
             ${{ env.PYTHON_VERSION }}-archive-
 
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
       - name: Install dependencies
         run: pipenv sync
         env:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -48,6 +48,17 @@ jobs:
           restore-keys: |
             ${{ env.PYTHON_VERSION }}-cron-
 
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
       - name: Install dependencies
         run: pipenv sync
         env:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -46,8 +46,7 @@ jobs:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-cron-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            ${{ env.PYTHON_VERSION }}-
-            pip-
+            ${{ env.PYTHON_VERSION }}-cron-
 
       - name: Install dependencies
         run: pipenv sync

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,6 +5,9 @@ on:
     # Set any time that you'd like scrapers to run (in UTC)
     - cron: "1 6 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - fix-separate-cache-key
 
 env:
   CI: true
@@ -41,7 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ env.PYTHON_VERSION }}-cron-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
             ${{ env.PYTHON_VERSION }}-
             pip-

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,9 +5,6 @@ on:
     # Set any time that you'd like scrapers to run (in UTC)
     - cron: "1 6 * * *"
   workflow_dispatch:
-  push:
-    branches:
-      - fix-separate-cache-key
 
 env:
   CI: true
@@ -44,9 +41,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: ${{ env.PYTHON_VERSION }}-cron-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
-            ${{ env.PYTHON_VERSION }}-cron-
+            ${{ env.PYTHON_VERSION }}-
+            pip-
 
       - name: Check and conditionally remove invalid virtual environment
         run: |


### PR DESCRIPTION
- Fix cron job failures by removing invalid .venv cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow reliability by ensuring that invalid or incomplete Python virtual environments are detected and rebuilt automatically during workflow runs.
  - Corrected the cache key for Python dependencies to prevent caching issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->