### PR TITLE
Enable logging and add Playwright browser install

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=False &
+pipenv run scrapy list | xargs -I {} pipenv run scrapy crawl {} -s LOG_ENABLED=True &
 
 # Output to the screen every 9 minutes to prevent a travis timeout
 # https://stackoverflow.com/a/40800348

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -62,6 +62,9 @@ jobs:
         env:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Playwright browsers
+        run: pipenv run playwright install --with-deps firefox
+
       - name: Run scrapers
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
+      - name: Install Playwright browsers
+        run: pipenv run playwright install --with-deps firefox
+
       - name: Run scrapers
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH


### PR DESCRIPTION
## Summary
- Enable logging in deploy script (`LOG_ENABLED=True`) for better debugging of scraper failures
- Add missing Playwright browser install step to both staging and cron workflows, fixing `losca_Board_of_ed` spider which requires Firefox

## Test plan
- [x] Verify staging workflow runs with logging enabled
- [x] Verify `losca_Board_of_ed` spider can launch Firefox and scrape successfully in staging and cron