### PR TITLE
Add playwright dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,8 @@ scrapy = "==2.11.2"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
+scrapy-playwright = "*"
+playwright = "*"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4ef91368dd6568776422d4c31a9f7aebc45a9b82ec2faadb10f992dee7f3cc5d"
+            "sha256": "a24e3d4aacbe4a11e8f628d8f0a6c923d918cd1540e676da6a0a1e61ec6eb9a8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -304,6 +304,59 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.16.1"
         },
+        "greenlet": {
+            "hashes": [
+                "sha256:04633da773ae432649a3f092a8e4add390732cc9e1ab52c8ff2c91b8dc86f202",
+                "sha256:04e6a202cde56043fd355fefd1552c4caa5c087528121871d950eb4f1b51fa99",
+                "sha256:050703a60603db0e817364d69e048c70af299040c13a7e67792b9e62d4571196",
+                "sha256:0bc06a78fa3ffbe2a75f1ebc7e040eacf6fa1050a9432953ab111fbbbf0d03c1",
+                "sha256:0d2a78e6f1bf3f1672df91e212a2f8314e1e7c922f065d14cbad4bc815059467",
+                "sha256:15871afc0d78ec87d15d8412b337f287fc69f8f669346e391585824970931c48",
+                "sha256:2acb30e77042f747ca81f0a10cc153296567e92e666c5e1b117f4595afd43352",
+                "sha256:2c7429f6e9cea7cbf2637d86d3db12806ba970f7f972fcab39d6b54b4457cbaf",
+                "sha256:34cc7cf8ab6f4b85298b01e13e881265ee7b3c1daf6bc10a2944abc15d4f87c3",
+                "sha256:3828b309dfb1f117fe54867512a8265d8d4f00f8de6908eef9b885f4d8789062",
+                "sha256:393c03c26c865f17f31d8db2f09603fadbe0581ad85a5d5908b131549fc38217",
+                "sha256:4544ab2cfd5912e42458b13516429e029f87d8bbcdc8d5506db772941ae12493",
+                "sha256:45fcea7b697b91290b36eafc12fff479aca6ba6500d98ef6f34d5634c7119cbe",
+                "sha256:472841de62d60f2cafd60edd4fd4dd7253eb70e6eaf14b8990dcaf177f4af957",
+                "sha256:499b809e7738c8af0ff9ac9d5dd821cb93f4293065a9237543217f0b252f950a",
+                "sha256:5bf0d7d62e356ef2e87e55e46a4e930ac165f9372760fb983b5631bb479e9d3a",
+                "sha256:5ceb29d1f74c7280befbbfa27b9bf91ba4a07a1a00b2179a5d953fc219b16c42",
+                "sha256:60c06b502d56d5451f60ca665691da29f79ed95e247bcf8ce5024d7bbe64acb9",
+                "sha256:6712bfd520530eb67331813f7112d3ee18e206f48b3d026d8a96cd2d2ad20251",
+                "sha256:67725ae9fea62c95cf1aa230f1b8d4dc38f7cd14f6103d1df8a5a95657eb8e54",
+                "sha256:6dff6433742073e5b6ad40953a78a0e8cddcb3f6869e5ea635d29a810ca5e7d0",
+                "sha256:6e8fe0c72603201a86b2e038daf9b6c8570715f8779566419cff543b6ace88de",
+                "sha256:7123b29e6bad2f3f89681be4ef316480fca798ebe8d22fbaced9cc3775007a4f",
+                "sha256:752c896a8c976548faafe8a306d446c6a4c68d4fd24699b84d4393bd9ac69a8e",
+                "sha256:7d951e7d628a6e8b68af469f0fe4f100ef64c4054abeb9cdafbfaa30a920c950",
+                "sha256:87b791dd0e031a574249af717ac36f7031b18c35329561c1e0368201c18caf1f",
+                "sha256:a145f4b1c4ed7a2c94561b7f18b4beec3d3fb6f0580db22f7ed1d544e0620b34",
+                "sha256:a5e4b25e855800fba17713020c5c33e0a4b7a1829027719344f0c7c8870092a2",
+                "sha256:ac8db07bced2c39b987bba13a3195f8157b0cfbce54488f86919321444a1cc3c",
+                "sha256:acabf468466d18017e2ae5fbf1a5a88b86b48983e550e1ae1437b69a83d9f4ac",
+                "sha256:bd593db7ee1fa8a513a48a404f8cc4126998a48025e3f5cbbc68d51be0a6bf66",
+                "sha256:bdd67619cefe1cc9fcab57c8853d2bb36eca9f166c0058cc0d428d471f7c785c",
+                "sha256:c11fe0cfb0ce33132f0b5d27eeadd1954976a82e5e9b60909ec2c4b884a55382",
+                "sha256:c5445ddb7b586d870dad32ca9fc47c287d6022a528d194efdb8912093c5303ad",
+                "sha256:c816554eb33e7ecf9ba4defcb1fd8c994e59be6b4110da15480b3e7447ea4286",
+                "sha256:c8317d732e2ae0935d9ed2af2ea876fa714cf6f3b887a31ca150b54329b0a6e9",
+                "sha256:cc1d01bdd67db3e5711e6246e451d7a0f75fae7bbf40adde129296a7f9aa7cc9",
+                "sha256:ce8aed6fdd5e07d3cbb988cbdc188266a4eb9e1a52db9ef5c6526e59962d3933",
+                "sha256:d5583b2ffa677578a384337ee13125bdf9a427485d689014b39d638a4f3d8dbe",
+                "sha256:d7456e67b0be653dfe643bb37d9566cd30939c80f858e2ce6d2d54951f75b14a",
+                "sha256:dbe0e81e24982bb45907ca20152b31c2e3300ca352fdc4acbd4956e4a2cbc195",
+                "sha256:e3f03ddd7142c758ab41c18089a1407b9959bd276b4e6dfbd8fd06403832c87a",
+                "sha256:e66872daffa360b2537170b73ad530f14fa31785b1bc78080125d92edf0a6def",
+                "sha256:edbf4ab9a7057ee430a678fe2ef37ea5d69125d6bdc7feb42ed8d871c737e63b",
+                "sha256:f2cc88b50b9006b324c1b9f5f3552f9d4564c78af57cdfb4c7baf4f0aa089146",
+                "sha256:f96e2bb8a56b7e1aed1dbfbbe0050cb2ecca99c7c91892fd1771e3afab63b3e3",
+                "sha256:fd904626b8779810062cb455514594776e3cba3b8c0ba4939894df9f7b384971"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.2.5"
+        },
         "hyperlink": {
             "hashes": [
                 "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b",
@@ -543,6 +596,21 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.4.0"
         },
+        "playwright": {
+            "hashes": [
+                "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117",
+                "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99",
+                "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b",
+                "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71",
+                "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa",
+                "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606",
+                "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8",
+                "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.58.0"
+        },
         "pyasn1": {
             "hashes": [
                 "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629",
@@ -566,6 +634,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.22"
+        },
+        "pyee": {
+            "hashes": [
+                "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8",
+                "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==13.0.1"
         },
         "pydispatcher": {
             "hashes": [
@@ -747,6 +823,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.11.2"
+        },
+        "scrapy-playwright": {
+            "hashes": [
+                "sha256:ac030c6ccf9b6f20c899795b48d5552bad3a25772f5a5441759fde99a127da00",
+                "sha256:e2200610d5619cc08c747484810efc55bc88de00324e2ccf5a1f74942295243e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.0.44"
         },
         "scrapy-sentry-errors": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Add `scrapy-playwright` and `playwright` to Pipfile for the `losca_Board_of_ed` spider which requires a browser to render the LAUSD calendar
- Minimal lockfile change — only adds playwright, greenlet, pyee, scrapy-playwright entries