### PR TITLE
Add daily refresh staging workflow

### DIFF
--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -1,0 +1,284 @@
+name: Refresh Staging
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+env:
+  CI: true
+  PYTHON_VERSION: 3.11
+  PIPENV_VENV_IN_PROJECT: true
+
+jobs:
+  merge-and-prepare:
+    if: github.ref == 'refs/heads/staging' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: write
+      pull-requests: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge open PRs into staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SKIPPED_PRS=""
+          MERGED_PRS=""
+
+          PRS=$(gh pr list --state open --json number,author,isDraft \
+            --jq '[.[] | select(.author.is_bot == false and .isDraft == false)] | .[].number')
+
+          if [ -z "$PRS" ]; then
+            echo "No open PRs to merge"
+          else
+            for PR in $PRS; do
+              echo "::group::Processing PR #$PR"
+
+              if ! git fetch origin "refs/pull/$PR/head:pr-$PR"; then
+                echo "::warning::Could not fetch PR #$PR, skipping"
+                echo "::endgroup::"
+                continue
+              fi
+
+              if git merge-base --is-ancestor "pr-$PR" staging; then
+                echo "PR #$PR is already merged into staging, skipping"
+                echo "::endgroup::"
+                continue
+              fi
+
+              if git merge "pr-$PR" --no-edit; then
+                echo "Successfully merged PR #$PR"
+                MERGED_PRS="${MERGED_PRS:+$MERGED_PRS }#$PR"
+              else
+                echo "::warning::Merge conflict on PR #$PR, skipping"
+                git merge --abort
+                SKIPPED_PRS="${SKIPPED_PRS:+$SKIPPED_PRS }#$PR"
+              fi
+
+              echo "::endgroup::"
+            done
+          fi
+
+          echo "SKIPPED_PRS=$SKIPPED_PRS" >> "$GITHUB_ENV"
+          echo "MERGED_PRS=$MERGED_PRS" >> "$GITHUB_ENV"
+          echo "Merged: $MERGED_PRS"
+          echo "Skipped: $SKIPPED_PRS"
+
+      - name: Notify Slack of merge conflicts
+        if: env.SKIPPED_PRS != ''
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "channel": "${{ secrets.SLACK_CHANNEL_NAME }}",
+              "text": ":warning: *Staging refresh: merge conflicts*\nPRs skipped due to conflicts: ${{ env.SKIPPED_PRS }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+            }'
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: pip install --user pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif ! .venv/bin/python --version 2>&1 | grep -q "Python ${{ env.PYTHON_VERSION }}"; then
+            echo "Virtual environment Python version mismatch. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync --dev
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Auto-fix lint
+        run: |
+          pipenv run isort .
+          pipenv run black .
+
+      - name: Commit lint fixes
+        run: |
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "Auto-fix lint errors after merge"
+          fi
+
+      - name: Verify lint
+        run: |
+          pipenv run isort . --check-only
+          pipenv run black . --check
+          pipenv run flake8 .
+
+      - name: Run tests
+        id: tests
+        run: |
+          pipenv run pytest || [ $? -eq 5 ]
+
+      - name: Notify Slack of test failure
+        if: failure() && steps.tests.outcome == 'failure'
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "channel": "${{ secrets.SLACK_CHANNEL_NAME }}",
+              "text": ":x: *Staging refresh: tests failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+            }'
+
+      - name: Push staging
+        run: git push origin staging
+
+  crawl:
+    needs: merge-and-prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CITY_SCRAPERS_ENV: staging
+      SCRAPY_SETTINGS_MODULE: city_scrapers.settings.staging
+      AUTOTHROTTLE_MAX_DELAY: 30.0
+      AUTOTHROTTLE_START_DELAY: 1.5
+      AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+      AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+      AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+      AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+    steps:
+      - name: Clean Azure staging container
+        run: |
+          az storage blob delete-batch \
+            --account-name "${{ secrets.AZURE_ACCOUNT_NAME }}" \
+            --account-key "${{ secrets.AZURE_ACCOUNT_KEY }}" \
+            --source "${{ secrets.AZURE_STAGING_CONTAINER }}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif ! .venv/bin/python --version 2>&1 | grep -q "Python ${{ env.PYTHON_VERSION }}"; then
+            echo "Virtual environment Python version mismatch. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Playwright browsers
+        run: pipenv run playwright install --with-deps firefox
+
+      - name: Run scrapers
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          ./.deploy.sh
+
+      - name: Combine output feeds
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  refresh-db:
+    needs: crawl
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 15
+    steps:
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Delete meetings without assignments
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          heroku run --no-tty -a "${{ secrets.HEROKU_STAGING_APP_NAME }}" -- python manage.py shell <<'PYEOF'
+          from documenters.meetings.models import Meeting
+
+          slug = '${{ secrets.PROGRAM_SLUG }}'
+          program_meetings = Meeting.objects.filter(programs__slug=slug)
+          without_assignments = program_meetings.filter(assignments__isnull=True).distinct()
+          count = without_assignments.count()
+          without_assignments.delete()
+          print(f'Deleted {count} meetings without assignments')
+          PYEOF
+
+      - name: Queue data import
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          heroku run --no-tty -a "${{ secrets.HEROKU_STAGING_APP_NAME }}" -- python manage.py shell <<'PYEOF'
+          from documenters.accounts.models import Program
+          from documenters.meetings.tasks import handle_meetings_feed_endpoint
+
+          program = Program.objects.filter(name__icontains='${{ secrets.PROGRAM_NAME }}').first()
+          print(f'Queuing import from: {program.meetings_feed_endpoint}')
+          handle_meetings_feed_endpoint.send(program.meetings_feed_endpoint)
+          PYEOF
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
## Summary
- Automates daily staging refresh: merge open PRs, lint, test, crawl, refresh Heroku DB.
- Adapted from [fortx PR #39](https://github.com/City-Bureau/city-scrapers-fortx/pull/39); adds Playwright browser install in the crawl job (losca-specific).
- Merge to `main` required for workflow to appear in the Actions tab and enable the cron schedule.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger `Refresh Staging` via `workflow_dispatch` from Actions tab
- [ ] Verify each job succeeds: `merge-and-prepare` → `crawl` → `refresh-db`
- [ ] Confirm Slack notifications on conflict/test-failure paths
- [ ] Confirm scheduled run at 03:00 UTC the following day